### PR TITLE
Feature/#3 determine if path is directory or file

### DIFF
--- a/src/input_args.rs
+++ b/src/input_args.rs
@@ -28,7 +28,7 @@ pub enum Commands {
 pub struct SeiArgs {
     /// Pass the path to the directory or file you wish to convert.
     #[arg(short, long)]
-    path: PathBuf,
+    pub path: PathBuf,
 }
 
 #[derive(Args, Debug)]
@@ -36,7 +36,7 @@ pub struct SeiArgs {
 pub struct MetArgs {
     /// Pass the path to the directory or file you wish to convert.
     #[arg(short, long)]
-    path: PathBuf,
+    pub path: PathBuf,
 }
 
 #[derive(Args, Debug)]
@@ -44,5 +44,5 @@ pub struct MetArgs {
 pub struct AstArgs {
     /// Pass the path to the directory or file you wish to convert.
     #[arg(short, long)]
-    path: PathBuf,
+    pub path: PathBuf,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,19 @@
-use chrysalis::input_args::{Cli, Commands};
+use chrysalis::{
+    input_args::{Cli, Commands},
+    utils::validation::is_dir_or_file,
+};
 
 fn main() {
     let cli = Cli::default();
-
     match &cli.command {
         Commands::Sei(val) => {
-            println!("{:?}", val);
+            println!("{:?}", is_dir_or_file(&val.path));
         }
         Commands::Met(val) => {
-            println!("{:?}", val);
+            println!("{:?}", is_dir_or_file(&val.path));
         }
         Commands::Ast(val) => {
-            println!("{:?}", val);
+            println!("{:?}", is_dir_or_file(&val.path));
         }
     };
 }

--- a/src/utils/validation.rs
+++ b/src/utils/validation.rs
@@ -1,1 +1,26 @@
-// TODO: 与えられたパス引数がディレクトリ・ファイルを判別するutil function
+use std::path::PathBuf;
+
+/// Enum representing the type of a path.
+#[derive(Debug)]
+pub enum PathType {
+    File,
+    Directory,
+    NotFound,
+}
+
+/// Determines whether a given path is a directory or a file.
+///
+/// # Arguments
+///
+/// * `path` - A reference to a `PathBuf` representing the path to be checked.
+///
+/// # Returns
+///
+/// * `PathType` - The type of the path: `File`, `Directory`, or `NotFound`.
+pub fn is_dir_or_file(path: &PathBuf) -> PathType {
+    match path {
+        path if path.is_dir() => PathType::Directory,
+        path if path.is_file() => PathType::File,
+        _ => PathType::NotFound,
+    }
+}


### PR DESCRIPTION
## Issue ticket

* #3

## 実装した機能

* 渡されたパスがファイル・ディレクトリ・該当なしの判別を行うis_dir_or_file純粋汎用関数を実装

## 変更内容

* main関数内でis_dir_or_file関数を使用するように変更

## 備考

* 無し

Closed #3
